### PR TITLE
Add Contains and ContainsAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ options.
 func Test(t *testing.T) {
     message := "foo"
     assert.Equal(t, message, "bar")
-    // message (-got +want): {string}:
-    //          -: "foo"
-    //          +: "bar"
-
+    // message (-got +want):  string(
+    // - 	"foo",
+    // + 	"bar",
+    //   )
     p := Person{Name: "Alice"}
     assert.Equal(t, p, Person{Name: "Bob"})
-    // p (-got +want): {domain_test.Person}.Name:
-    //          -: "Alice"
-    //          +: "Bob"
+    // p (-got +want): domain_test.Person{
+    // - 	Name: "Alice",
+    // + 	Name: "Bob",
+    //  }
 }
 ```

--- a/assert.go
+++ b/assert.go
@@ -198,11 +198,12 @@ func sliceContains(t testingT, got []interface{}, want interface{}, expr string,
 	return false
 }
 
-func SliceContainsAllOf(t testingT, got, want interface{}, opts ...cmp.Option) bool {
+// ContainsContainsAllOf asserts that got contains all items of want.
+func ContainsAllOf(t testingT, got, want interface{}, opts ...cmp.Option) bool {
 	t.Helper()
 
 	if reflect.TypeOf(got).Kind() != reflect.Slice || reflect.TypeOf(want).Kind() != reflect.Slice {
-		t.Error("SliceContainsAllOf requires slice")
+		t.Error("ContainsAllOf requires slice")
 		return false
 	}
 
@@ -224,22 +225,18 @@ func SliceContainsAllOf(t testingT, got, want interface{}, opts ...cmp.Option) b
 }
 
 func sliceContainsAllOf(t testingT, got, want, missing []interface{}, opts ...cmp.Option) []interface{} {
+	if len(want) == 0 {
+		return missing
+	}
+
 	for i := 0; i < len(got); i++ {
 		if eq := cmp.Equal(got[i], want[0], opts...); eq {
-			if len(want) > 1 {
-				return sliceContainsAllOf(t, append(got[:i], got[i+1:]...), want[1:], missing, opts...)
-			} else {
-				return missing
-			}
+			return sliceContainsAllOf(t, append(got[:i], got[i+1:]...), want[1:], missing, opts...)
 		}
 	}
 
 	missing = append(missing, want[0])
-	if len(want) > 1 {
-		return sliceContainsAllOf(t, got, want[1:], missing, opts...)
-	} else {
-		return missing
-	}
+	return sliceContainsAllOf(t, got, want[1:], missing, opts...)
 }
 
 // True asserts that got is true.

--- a/assert.go
+++ b/assert.go
@@ -167,9 +167,9 @@ func Contains(t testingT, got, want interface{}, opts ...cmp.Option) bool {
 	}
 }
 
-// ContainsContainsAllOf asserts that got contains all items of want.
+// ContainsAll asserts that got contains all items of want.
 // The got and want parameters must be slices.
-func ContainsAllOf(t testingT, got, want interface{}, opts ...cmp.Option) bool {
+func ContainsAll(t testingT, got, want interface{}, opts ...cmp.Option) bool {
 	t.Helper()
 
 	gotKind := reflect.TypeOf(got).Kind()
@@ -182,9 +182,9 @@ func ContainsAllOf(t testingT, got, want interface{}, opts ...cmp.Option) bool {
 			t.Error("want must be slice")
 			return false
 		}
-		missing = sliceContainsAllOf(castInterfaceToSlice(want), castInterfaceToSlice(got), opts...)
+		missing = sliceContainsAll(castInterfaceToSlice(want), castInterfaceToSlice(got), opts...)
 	default:
-		msg := fmt.Sprintf("has unsupported type for ContainsAllOf: %q", reflect.TypeOf(got).Kind())
+		msg := fmt.Sprintf("has unsupported type for ContainsAll: %q", reflect.TypeOf(got).Kind())
 		t.Error(formatError(getArg(1)(), msg))
 		return false
 	}
@@ -365,7 +365,7 @@ func sliceContains(t testingT, got []interface{}, want interface{}, expr string,
 	return false
 }
 
-func sliceContainsAllOf(want []interface{}, got []interface{}, opts ...cmp.Option) []interface{} {
+func sliceContainsAll(want []interface{}, got []interface{}, opts ...cmp.Option) []interface{} {
 	var missing []interface{}
 outerLoop:
 	for _, w := range want {

--- a/assert_test.go
+++ b/assert_test.go
@@ -3,10 +3,11 @@ package assert
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func testGetArg(interface{}) string { return getArg(0)() }
@@ -221,6 +222,14 @@ func TestAssertContainsAllOf(t *testing.T) {
 				want := []string{"yellow"}
 				return ContainsAllOf(mt, out, want)
 			}, ``)
+		})
+
+		t.Run("when input has duplicates", func(t *testing.T) {
+			assert(t, func(mt *mockTestingT) bool {
+				out := []string{"red", "orange", "yellow"}
+				want := []string{"yellow", "yellow"}
+				return ContainsAllOf(mt, out, want)
+			}, `out does not contain:`)
 		})
 
 		t.Run("when does not contain all of input", func(t *testing.T) {

--- a/assert_test.go
+++ b/assert_test.go
@@ -55,14 +55,14 @@ func TestAssertNotEqual(t *testing.T) {
 			id := 1
 			return NotEqual(mt, id, 1)
 		},
-		`id: should not equal 1`)
+		`id should not equal 1`)
 
 	assert(t,
 		func(mt *mockTestingT) bool {
 			subject := "noun"
 			return NotEqual(mt, subject, subject)
 		},
-		`subject: should not equal "noun"`)
+		`subject should not equal "noun"`)
 
 	assert(t,
 		func(mt *mockTestingT) bool {
@@ -71,7 +71,7 @@ func TestAssertNotEqual(t *testing.T) {
 			}{1}
 			return NotEqual(mt, subject, subject)
 		},
-		`subject: should not equal struct { ID int "json:\"id\"" }{ID:1}`)
+		`subject should not equal struct { ID int "json:\"id\"" }{ID:1}`)
 }
 
 func TestAssertJSONEqual(t *testing.T) {
@@ -195,10 +195,20 @@ func TestAssertContains(t *testing.T) {
 	t.Run("when input type is not supported", func(t *testing.T) {
 		assert(t,
 			func(mt *mockTestingT) bool {
-				out := map[string]string{}
+				out := 1
 				return Contains(mt, out, 1)
 			},
-			`out has unsupported type for Contains: "map"`,
+			`out has unsupported type for Contains: "int"`,
+		)
+	})
+
+	t.Run("when got is string but want is not", func(t *testing.T) {
+		assert(t,
+			func(mt *mockTestingT) bool {
+				out := "red orange yellow"
+				return Contains(mt, out, 1)
+			},
+			`got and want must be the same type`,
 		)
 	})
 }
@@ -220,6 +230,14 @@ func TestAssertContainsAllOf(t *testing.T) {
 					want := []string{"blue", "red", "purple"}
 					return ContainsAllOf(mt, out, want)
 				}, `out does not contain:`)
+		})
+
+		t.Run("when want contains more than got", func(t *testing.T) {
+			assert(t, func(mt *mockTestingT) bool {
+				out := []string{"red", "orange", "yellow"}
+				want := []string{"red", "orange", "yellow", "blue"}
+				return ContainsAllOf(mt, out, want)
+			}, `out does not contain:`)
 		})
 
 		t.Run("when does not contain any of input", func(t *testing.T) {
@@ -299,6 +317,25 @@ func TestAssertContainsAllOf(t *testing.T) {
 				`out does not contain:`)
 		})
 	})
+
+	t.Run("when want is not a slice", func(t *testing.T) {
+		assert(t,
+			func(mt *mockTestingT) bool {
+				out := []int{1, 2, 3}
+				want := 3
+				return ContainsAllOf(mt, out, want)
+			},
+			`want must be slice`)
+	})
+
+	t.Run("when input is of unsupported type", func(t *testing.T) {
+		assert(t,
+			func(mt *mockTestingT) bool {
+				out := -1
+				return ContainsAllOf(mt, out, 3)
+			},
+			`out has unsupported type for ContainsAllOf: "int"`)
+	})
 }
 
 func TestAssertTrue(t *testing.T) {
@@ -342,7 +379,7 @@ func TestAssertMatch(t *testing.T) {
 			log := "hello, world!"
 			return Match(mt, log, "^goodbye.*$")
 		},
-		`log: got "hello, world!", which doesn't match "^goodbye.*$"`,
+		`log ("hello, world!") doesn't match "^goodbye.*$"`,
 	)
 
 	assert(t, func(mt *mockTestingT) bool {
@@ -409,7 +446,7 @@ func TestAssertNotNil(t *testing.T) {
 			var thing *struct{}
 			return NotNil(mt, thing)
 		},
-		`thing: got <nil>, want not nil`,
+		`thing was not nil`,
 	)
 }
 
@@ -423,7 +460,7 @@ func TestAssertEmpty(t *testing.T) {
 			val := "abc"
 			return Empty(mt, val)
 		},
-		`val: got "abc", want empty`,
+		`val ("abc") was not empty`,
 	)
 
 	assert(t,
@@ -431,7 +468,7 @@ func TestAssertEmpty(t *testing.T) {
 			val := []int{1, 2, 3}
 			return Empty(mt, val)
 		},
-		`val: got [1 2 3], want empty`,
+		`val ([1 2 3]) was not empty`,
 	)
 }
 
@@ -445,7 +482,7 @@ func TestAssertNotEmpty(t *testing.T) {
 			var val string
 			return NotEmpty(mt, val)
 		},
-		`val: got "", want not empty`,
+		`val was empty`,
 	)
 
 	assert(t,
@@ -453,7 +490,7 @@ func TestAssertNotEmpty(t *testing.T) {
 			var val []int
 			return NotEmpty(mt, val)
 		},
-		`val: got [], want not empty`,
+		`val was empty`,
 	)
 }
 
@@ -468,7 +505,7 @@ func TestErrorContains(t *testing.T) {
 			err := fmt.Errorf("foo")
 			return ErrorContains(mt, err, "bar")
 		},
-		`err: got "foo", which does not contain "bar"`,
+		`err ("foo") does not contain "bar"`,
 	)
 
 	assert(t,
@@ -476,7 +513,7 @@ func TestErrorContains(t *testing.T) {
 			var err error
 			return ErrorContains(mt, err, "foo")
 		},
-		`err: got <nil>, want not nil`,
+		`err was not nil`,
 	)
 }
 

--- a/assert_test.go
+++ b/assert_test.go
@@ -214,13 +214,13 @@ func TestAssertContains(t *testing.T) {
 	})
 }
 
-func TestAssertContainsAllOf(t *testing.T) {
+func TestAssertContainsAll(t *testing.T) {
 	t.Run("when input is slice of strings", func(t *testing.T) {
 		t.Run("when contains all of input", func(t *testing.T) {
 			assert(t, func(mt *mockTestingT) bool {
 				out := []string{"red", "orange", "yellow"}
 				want := []string{"yellow"}
-				return ContainsAllOf(mt, out, want)
+				return ContainsAll(mt, out, want)
 			}, ``)
 		})
 
@@ -228,7 +228,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 			assert(t, func(mt *mockTestingT) bool {
 				out := []string{"red", "orange", "yellow"}
 				want := []string{"yellow", "yellow"}
-				return ContainsAllOf(mt, out, want)
+				return ContainsAll(mt, out, want)
 			}, `out does not contain:`)
 		})
 
@@ -237,7 +237,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 				func(mt *mockTestingT) bool {
 					out := []string{"red", "orange", "yellow"}
 					want := []string{"blue", "red", "purple"}
-					return ContainsAllOf(mt, out, want)
+					return ContainsAll(mt, out, want)
 				}, `out does not contain:`)
 		})
 
@@ -245,7 +245,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 			assert(t, func(mt *mockTestingT) bool {
 				out := []string{"red", "orange", "yellow"}
 				want := []string{"red", "orange", "yellow", "blue"}
-				return ContainsAllOf(mt, out, want)
+				return ContainsAll(mt, out, want)
 			}, `out does not contain:`)
 		})
 
@@ -254,7 +254,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 				func(mt *mockTestingT) bool {
 					out := []string{"red", "orange", "yellow"}
 					want := []string{"blue", "purple"}
-					return ContainsAllOf(mt, out, want)
+					return ContainsAll(mt, out, want)
 				}, `out does not contain:`)
 		})
 	})
@@ -275,7 +275,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 					want := []x{
 						{A: 1, B: true},
 					}
-					return ContainsAllOf(mt, out, want)
+					return ContainsAll(mt, out, want)
 				},
 				``)
 		})
@@ -290,7 +290,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 					want := []x{
 						{A: 1, B: false},
 					}
-					return ContainsAllOf(mt, out, want, cmpopts.IgnoreFields(x{}, "B"))
+					return ContainsAll(mt, out, want, cmpopts.IgnoreFields(x{}, "B"))
 				},
 				``)
 		})
@@ -306,7 +306,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 						{A: 1, B: true},
 						{A: 3, B: true},
 					}
-					return ContainsAllOf(mt, out, want)
+					return ContainsAll(mt, out, want)
 				},
 				`out does not contain:`)
 		})
@@ -321,7 +321,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 					want := []x{
 						{A: 3, B: true},
 					}
-					return ContainsAllOf(mt, out, want)
+					return ContainsAll(mt, out, want)
 				},
 				`out does not contain:`)
 		})
@@ -332,7 +332,7 @@ func TestAssertContainsAllOf(t *testing.T) {
 			func(mt *mockTestingT) bool {
 				out := []int{1, 2, 3}
 				want := 3
-				return ContainsAllOf(mt, out, want)
+				return ContainsAll(mt, out, want)
 			},
 			`want must be slice`)
 	})
@@ -341,9 +341,9 @@ func TestAssertContainsAllOf(t *testing.T) {
 		assert(t,
 			func(mt *mockTestingT) bool {
 				out := -1
-				return ContainsAllOf(mt, out, 3)
+				return ContainsAll(mt, out, 3)
 			},
-			`out has unsupported type for ContainsAllOf: "int"`)
+			`out has unsupported type for ContainsAll: "int"`)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/deliveroo/assert-go
 go 1.12
 
 require (
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.5.5
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Change list:
* Extends the `Contains` assertion to work with slices.
* Adds a `ContainsAll` assertion for slices that handles duplicate values.
* Updates `go-cmp` from `v0.2.0` to `v0.5.5` improving diff report output and cmp options.

I've been wanting to add a `Contains` function for slices so that we don't have to rely on assert-go _and_ testify everywhere in our repos. I've also added a `ContainsAll` function because I think it's deceptively easy to write tests with a nested loop between two slices and not consider how you want to handle duplicate values. I've gone for a nested loop over a recursive function for this because at large slice sizes the recursive performance starts to trail compared to the more imperative nested loop, although not by much (likely due to Go's lack of tail call optimisation):

```
Benchmark/ContainsAllOf
Benchmark/ContainsAllOf-8         	                       1	44109216843 ns/op
Benchmark/ContainsAllOfWithNestedLoop
Benchmark/ContainsAllOfWithNestedLoop-8         	       1	40809058509 ns/op
```

I originally just bumped the `go-cmp` version because I wanted better diff reports for the two new functions. However, there's also a [few improvements](https://github.com/google/go-cmp/releases) over `v0.2.0` that we could be leveraging, including more readable diffs produced as literals in pseudo Go syntax. These changes also included the sneaky addition of randomly substituting in special white space characters into diff reports to make them non-deterministic and therefore, by design, non-testable. As a result, I've had to update our tests here that rely on report output to only test the prefixing that we apply. The alternative is defining a custom, deterministic reporter which undermines the goal of providing a helpful wrapper library for a fuller-featured open source project.