### PR TITLE
Fix use of opts RegisterOptions

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -353,8 +353,8 @@ func castInterfaceToSlice(inter interface{}) []interface{} {
 }
 
 func sliceContains(t testingT, got []interface{}, want interface{}, expr string, opts ...cmp.Option) bool {
+	opts = append(opts, defaultOpts...)
 	for i := 0; i < len(got); i++ {
-		opts = append(opts, defaultOpts...)
 		if eq := cmp.Equal(got[i], want, opts...); eq {
 			return true
 		}

--- a/assert.go
+++ b/assert.go
@@ -366,6 +366,7 @@ func sliceContains(t testingT, got []interface{}, want interface{}, expr string,
 }
 
 func sliceContainsAll(want []interface{}, got []interface{}, opts ...cmp.Option) []interface{} {
+	opts = append(opts, defaultOpts...)
 	var missing []interface{}
 outerLoop:
 	for _, w := range want {

--- a/assert_test.go
+++ b/assert_test.go
@@ -352,13 +352,13 @@ func TestAssertContainsAll(t *testing.T) {
 
 func TestAssertTrue(t *testing.T) {
 	assert(t, func(mt *mockTestingT) bool {
-		enabled := true
+		const enabled = true
 		return True(mt, enabled)
 	}, ``)
 
 	assert(t,
 		func(mt *mockTestingT) bool {
-			enabled := false
+			const enabled = false
 			return True(mt, enabled)
 		},
 		`enabled (-got +want):`,
@@ -367,13 +367,13 @@ func TestAssertTrue(t *testing.T) {
 
 func TestAssertFalse(t *testing.T) {
 	assert(t, func(mt *mockTestingT) bool {
-		enabled := false
+		const enabled = false
 		return False(mt, enabled)
 	}, ``)
 
 	assert(t,
 		func(mt *mockTestingT) bool {
-			enabled := true
+			const enabled = true
 			return False(mt, enabled)
 		},
 		`enabled (-got +want):`,

--- a/assert_test.go
+++ b/assert_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func testGetArg(interface{}) string { return getArg(0)() }
+func testGetArg(_ interface{}) string { return getArg(0)() }
 
 func TestGetArgName(t *testing.T) {
 	t.Run("variable", func(t *testing.T) {

--- a/assert_test.go
+++ b/assert_test.go
@@ -546,7 +546,7 @@ func assert(t *testing.T, fn func(mt *mockTestingT) bool, want string) {
 		t.Errorf("error:\ngot:  %s\nwant prefix: %s", mt.err, want)
 	}
 	if ret != (want == "") {
-		t.Errorf("returned %v, want %v", ret, (want == ""))
+		t.Errorf("returned %v, want %v", ret, want == "")
 	}
 }
 


### PR DESCRIPTION
I noticed a couple of mistakes in use of `defaultOpts` as set by `RegisterOptions` in the new code recently added for `Contains` and `ContainsAll`.

This PR adds a test and fixes for the issues: see individual commits.

I also did some minor changes for warnings that show up in my IDE. See individual commits.